### PR TITLE
Adding error catching for malformed classads in agis-compat and AGIS suggested changes

### DIFF
--- a/src/htcondor_ce/web.py
+++ b/src/htcondor_ce/web.py
@@ -177,9 +177,9 @@ def agis_json(environ, start_response):
         try:
             ce_ad = {
                 "endpoint": ad['CollectorHost'],
-                "flavour": "HTCondor-CE",
-                "jobmanager": ad['OSG_BatchSystems'],
-                "name": ad['OSG_Resource'],
+                "flavour": "HTCONDOR-CE",
+                "jobmanager": ad['OSG_BatchSystems'].lower(),
+                "name": "%s-CE-HTCondorCE-%s" % (ad['OSG_ResourceGroup'], ad['CollectorHost'].split(':')[0]),
                 "site": ad['OSG_ResourceGroup'],
                 "status": "Production",
                 "type": "CE",


### PR DESCRIPTION
Adding error catching when the classad in the collector is malformed.  No form of logging works in the webapp.  Not stderr (set to /dev/null) and not the logging module.  Therefore, bad sites are appended to the json with the key "failed_ces".  

Additionally, change the format of the output to be compatible with AGIS requirements.
